### PR TITLE
Fix for mobile pages not loading

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -35,5 +35,8 @@ module.exports = {
     `gatsby-plugin-offline`,
     // For generating page metadata for search engines
     `gatsby-plugin-react-helmet`,
+    // Fixes issue where page not showing on mobile. 
+    //   Issue: https://github.com/gatsbyjs/gatsby/issues/13410
+    `gatsby-plugin-remove-serviceworker`
   ],
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gatsby-plugin-manifest": "^2.4.28",
     "gatsby-plugin-offline": "^3.2.27",
     "gatsby-plugin-react-helmet": "^3.3.10",
+    "gatsby-plugin-remove-serviceworker": "^1.0.0",
     "gatsby-source-filesystem": "^2.3.29",
     "gatsby-transformer-remark": "^2.8.34",
     "react": "^16.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5587,6 +5587,11 @@ gatsby-plugin-react-helmet@^3.3.10:
   dependencies:
     "@babel/runtime" "^7.10.3"
 
+gatsby-plugin-remove-serviceworker@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-remove-serviceworker/-/gatsby-plugin-remove-serviceworker-1.0.0.tgz#9fb433bc8bd766e14e1d3711c4ac6f051e1dff7c"
+  integrity sha1-n7QzvIvXZuFOHTcRxKxvBR4d/3w=
+
 gatsby-plugin-typescript@^2.4.18:
   version "2.4.18"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-typescript/-/gatsby-plugin-typescript-2.4.18.tgz#9361ef69f149f68e55ebf2d3f773b9aafce75df8"


### PR DESCRIPTION
There is known issue with gatsby-plugin-offline that can cause mobile
pages not to load.

https://github.com/gatsbyjs/gatsby/issues/13410